### PR TITLE
Improve passing of multiple command parameters

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -1,7 +1,7 @@
 name: "Test & Publish"
 on:
   schedule:
-    - cron:  '0 16 25 * *'
+    - cron: '0 16 25 * *'
     # Verify that (most) things work before running the monthly release.
   push:
     branches-ignore:
@@ -11,6 +11,7 @@ on:
       - 'LICENSE'
       - 'demo/**'
   create:
+  workflow_dispatch:
 
 env:
   IMAGE_TAG_LIST: "texlive-image-tags"

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -22,7 +22,7 @@ jobs:
     name: Log Workflow Information
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: "Git Revision"
         run: echo "${GITHUB_REF}"
       - name: "Github Event"
@@ -32,7 +32,7 @@ jobs:
     name: "Test: Create Minimal Image"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Obtain Installer
         run: .github/scripts/build-installer-image.sh
         # TODO: Can the separate jobs share this image?
@@ -46,7 +46,7 @@ jobs:
     name: "Test: Run Usage Examples"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Obtain Installer
         run: .github/scripts/build-installer-image.sh
       - name: "Build Test Image"
@@ -72,7 +72,7 @@ jobs:
       - test-run-examples
     if: startsWith(github.ref, 'refs/tags/pre-') || startsWith(github.ref, 'refs/tags/release-')
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Obtain Installer
         run: .github/scripts/build-installer-image.sh
       - name: Build images

--- a/README.md
+++ b/README.md
@@ -8,28 +8,27 @@ install additional packages from CTAN if and when needed.
 
 These images attempt to cover the following use cases:
 
- - Replace local TeXlive installations.
- - Build LaTeX documents in CI/CD pipelines.
- - Build legacy documents with old package versions.
+- Replace local TeXlive installations.
+- Build LaTeX documents in CI/CD pipelines.
+- Build legacy documents with old package versions.
 
 We currently publish the following images based on different selections
 from the TeXlive collections suggested by [the installer][install-tl]; 
 from smaller to larger:
 
- - [reitzig/texlive-minimal][minimal-dockerhub] ([profile][minimal-profile])
- - [reitzig/texlive-base][base-dockerhub] ([profile][base-profile])
- - [reitzig/texlive-base-luatex][base-luatex-dockerhub] ([profile][base-luatex-profile])
- - [reitzig/texlive-base-xetex][base-xetex-dockerhub] ([profile][base-xetex-profile])
- - [reitzig/texlive-full][full-dockerhub] ([profile][full-profile])
+- [reitzig/texlive-minimal][minimal-dockerhub] ([profile][minimal-profile])
+- [reitzig/texlive-base][base-dockerhub] ([profile][base-profile])
+- [reitzig/texlive-base-luatex][base-luatex-dockerhub] ([profile][base-luatex-profile])
+- [reitzig/texlive-base-xetex][base-xetex-dockerhub] ([profile][base-xetex-profile])
+- [reitzig/texlive-full][full-dockerhub] ([profile][full-profile])
 
 We also provide PoCs to demonstrate that more involved applications can
 be built on top of the base images provided here:
- 
- - [Serve a static set of pre-built documents.][demo-static-serve]
- <!-- TODO - LaTeX CI pipeline -->
- <!-- TODO - LaTeX build server. -->
- <!-- TODO - Document generation server. -->
 
+- [Serve a static set of pre-built documents.][demo-static-serve]
+<!-- TODO - LaTeX CI pipeline -->
+<!-- TODO - LaTeX build server. -->
+<!-- TODO - Document generation server. -->
 
 ## Usage
 
@@ -45,47 +44,50 @@ docker run --rm \
 
 Note:
 
- - This assumes that all TeXlive packages beyond what is contained in the
-   `texlive-base-luatex` image are listed in `Texlivefile`.
-   You can also use image `reitzig/texlive-full` instead if you are happy
-   with downloading a (way) larger image.
- - This may overwrite files in `out`. Chose a folder name that you currently
-   do not use.
+- This assumes that all TeXlive packages beyond what is contained in the
+  `texlive-base-luatex` image are listed in `Texlivefile`.
+  You can also use image `reitzig/texlive-full` instead if you are happy
+  with downloading a (way) larger image.
+- This may overwrite files in `out`. Chose a folder name that you currently
+  do not use.
 
 See the scripts in [`examples`][examples] for other ways to use the images.
 
 ### Dependencies
 
-Place a file called `Texlivefile`  with a list of required CTAN packages, 
-one name per line, in the source directory. 
+Place a file called `Texlivefile`  with a list of required CTAN packages,
+one name per line, in the source directory.
 The container will install all packages on that list before running the work command.
 
 ### Parameters
 
-You can adjust some defaults of the 
+You can adjust some defaults of the
     [main container script][entrypoint]
-by 
+by
     [setting environment variables][docker-set-env]
- 
- - `BUILDSCRIPT` (default: `build.sh`)  
-   If present, the given script will be executed unless a work command is specified.
- - `TEXLIVEFILE` (default: `Texlivefile`)  
-   The file to read dependencies from.
- - `OUTPUT` (default: `*.pdf *.log`)  
-   Shell pattern for all files that should be copied from the working to the output directory.
+
+- `BUILDSCRIPT` (default: `build.sh`)  
+  If present, the given script will be executed unless a work command is specified.
+- `TEXLIVEFILE` (default: `Texlivefile`)  
+  The file to read dependencies from.
+- `OUTPUT` (default: `*.pdf *.log`)  
+  Shell pattern for all files that should be copied from the working to the output directory.
 
 ### Debugging
 
 All output of the work command is collected in a single folder; extract it with:
 
-    docker cp $container:/work/tmp ./
-
+```bash
+docker cp $container:/work/tmp ./
+```
 
 ## Build
 
 Run
 
-    docker build -t texlive-base-luatex --build-arg "profile=base-luatex" .
+```bash
+docker build -t texlive-base-luatex --build-arg "profile=base-luatex" .
+```
 
 to build an image locally. Exchange `base-luatex` for any of the profile names in
 [`profiles`][profiles] to start from another baseline.
@@ -96,23 +98,21 @@ If you repeatedly need the same exact set of dependencies or even sources, it
 might make sense to create your own TeXlive Docker image.
 There are two ways to go about that:
 
- - Extend one of the existing images using your own Dockerfile (see [example][custom-dockerfile]);
-   install additional TeXlive (or even Alpine) packages, copy source files
-   or additional scripts into the appropriate folders, fix the work command, or ...
-    
- - Use [install-tl][install-tl] to create your own TeXlive installation profile. Make sure to
- 
+- Extend one of the existing images using your own Dockerfile (see [example][custom-dockerfile]);
+  install additional TeXlive (or even Alpine) packages, copy source files
+  or additional scripts into the appropriate folders, fix the work command, or ...
+- Use [install-tl][install-tl] to create your own TeXlive installation profile. Make sure to
+
     1. select platform `x86_64-linuxmusl` and
     2. manually change line `binary_x86_64-linux 1` in the resulting profile file
        to `binary_x86_64-linux 0`.
        <!-- Yup, it's a workaround; musl-only installs are apparently not well-supported.
             See a matching note in Dockerfile. Any advice is appreciated. -->
-   
+
    If you want to use your profile across different TeXlive versions,
    replace all occurrences of the TeXlive version (e.g. `2019`) with `${tlversion}`.
-       
+
    Copy the final file to [`profiles`][profiles] and run the regular build command.
-   
 
 <!-- Note: Repo-relative links will be rewritten by update-dockerhub-info.sh before pushing to Docker Hub -->
 [examples]: examples

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ docker run --rm \
     --volume `pwd`:/work/src:ro \
     --volume `pwd`/out:/work/out \
     reitzig/texlive-base-luatex \
-    work 'lualatex hello_world.tex'
+    work lualatex hello_world.tex
 ```
 
 Note:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,7 +79,8 @@ case "${command}" in
                 fi
                 ;;
             *)
-                work_command="${2}"
+                shift
+                work_command="$@"
 
                 if [[ -f "${SRC_DIR}/${BUILDSCRIPT}" ]]; then
                     echo "Work command overrides build script ${BUILDSCRIPT}."

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,34 +1,34 @@
-## Examples
+# Examples
 
 All examples share the same basic task:
 
- - compile document [`hello_world.tex`] with
- - dependencies given in [`Texlivefile`].
+- compile document [`hello_world.tex`] with
+- dependencies given in [`Texlivefile`].
 
 They go about it in different ways in order to showcase the flexibility
 of using TeXlive in this way -- and to _specify_ how they should work
 for testing.
 
- - [One-off build](one-off-build.sh) -- a single command that builds
-   a document from scratch.
- - [Complex build](complex-build.sh) -- shows how to use a custom build
-   script
- - [Repeated build](repeated-build.sh) -- shows how to rebuild a
-   document in the same container, potentially making use of temporary
-   files (e.g. TikZ externalization).
- - [Interactive build](interactive-build.sh) -- shows how to keep a 
-   TeXlive container alive and interact freely with it using `docker cp` 
-   and `docker exec`.
- - [Custom image](custom-image.sh) -- shows how do use a custom Docker
-   image to cover more specialized requirements such as pinning versions 
-   of TeXlive packages. If you need reproducible and/or archive builds, 
-   look here. 
- 
+- [One-off build](one-off-build.sh) -- a single command that builds
+  a document from scratch.
+- [Complex build](complex-build.sh) -- shows how to use a custom build
+  script
+- [Repeated build](repeated-build.sh) -- shows how to rebuild a
+  document in the same container, potentially making use of temporary
+  files (e.g. TikZ externalization).
+- [Interactive build](interactive-build.sh) -- shows how to keep a
+  TeXlive container alive and interact freely with it using `docker cp`
+  and `docker exec`.
+- [Custom image](custom-image.sh) -- shows how do use a custom Docker
+  image to cover more specialized requirements such as pinning versions
+  of TeXlive packages. If you need reproducible and/or archive builds,
+  look here.
+
 These are just a few examples -- you have to full power of Docker and
 the Linux running _in_ the container at your disposal. Go nuts!
 You may find some ideas in our [demos](../demo).
- 
-### How to run these
+
+## How to run the examples
 
 The examples can be run as shell scripts:
 
@@ -36,17 +36,18 @@ The examples can be run as shell scripts:
 ./one-off-build.sh
 ```
 
-_Note:_ 
- - The examples are tested to run with 
-     [`base-luatex`](../profiles/base-luatex.profile)
-   images. "Larger" images will also work.
- - If you want to try out a custom image, pass its tag to the example:
- 
+### Note
+
+- The examples are tested to run with
+  [`base-luatex`](../profiles/base-luatex.profile)
+  images. "Larger" images will also work.
+- If you want to try out a custom image, pass its tag to the example:
+
     ```bash
     ./one-off-build.sh texlive-base-luatex:local-testing
     ```
 
-### How to read these
+## How to read the examples
 
 The examples are executable for the purpose of testing.
 Some hoop-jumping is necessary to make them run both locally _and_
@@ -54,12 +55,12 @@ in CI/CD jobs which, unfortunately, has made them less readable.
 
 Here are some remarks that should help.
 
- - Script [_example_setup.sh] is `source`-ed from the top of each
-   script. If defines variables that are then used in the example 
-   scripts.
-   
-   - The first parameter is the name (and tag) of the image used to run 
-     the example; it is optional with default `reitzig/texlive-base-luatex`.  
-     It sets variable `$image` to this value.
-   - It sets variable `$tty_params` so that `docker run` et al. run
-     in both interactive and non-interactive shells.
+- Script [_example_setup.sh] is `source`-ed from the top of each
+  script. If defines variables that are then used in the example
+  scripts.
+
+  - The first parameter is the name (and tag) of the image used to run
+    the example; it is optional with default `reitzig/texlive-base-luatex`.
+    It sets variable `$image` to this value.
+  - It sets variable `$tty_params` so that `docker run` et al. run
+    in both interactive and non-interactive shells.

--- a/examples/one-off-build.sh
+++ b/examples/one-off-build.sh
@@ -12,7 +12,7 @@ docker run --name=tld-example ${tty_params} --rm \
     --volume `pwd`:/work/src:ro \
     --volume `pwd`/out:/work/out \
     ${image} \
-    work 'lualatex hello_world.tex'
+    work lualatex hello_world.tex
 
 mv out/* ./ && rm -rf out
 

--- a/examples/repeated-build.sh
+++ b/examples/repeated-build.sh
@@ -11,7 +11,7 @@ source "$(dirname $0)/_example_setup.sh" "${@}"
 docker run --name=tld-example ${tty_params} \
     --volume `pwd`:/work/src:ro \
     ${image} \
-    work 'lualatex hello_world.tex'
+    work lualatex hello_world.tex
 
 docker start --attach ${tty_params} tld-example
 docker cp tld-example:/work/out/ ./ \


### PR DESCRIPTION
Currently, the documentation recommends

    docker run ... work 'lualatex hello_world.tex'

I would like

    docker run ... work lualatex hello_world.tex

better. With this PR, both ways seem to possible.

BTW: On windows, I have to use double quotes.
