### PR TITLE
entrypoint.sh: allow TEXLIVEFILE to be in subdirectory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,6 +90,7 @@ case "${command}" in
 
         # Install dependencies
         hashfile="${TMP_DIR}/${TEXLIVEFILE}.sha"
+        mkdir -p $(dirname ${hashfile})
         if [[ -f "${SRC_DIR}/${TEXLIVEFILE}" ]]; then
             if ! sha256sum -c "${hashfile}" > /dev/null 2>&1; then
                 echo "Installing dependencies ..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,7 +90,8 @@ case "${command}" in
 
         # Install dependencies
         hashfile="${TMP_DIR}/${TEXLIVEFILE}.sha"
-        mkdir -p $(dirname ${hashfile})
+        mkdir -p "$(dirname "${hashfile}")"
+        
         if [[ -f "${SRC_DIR}/${TEXLIVEFILE}" ]]; then
             if ! sha256sum -c "${hashfile}" > /dev/null 2>&1; then
                 echo "Installing dependencies ..."


### PR DESCRIPTION
Currently the entrypoint exits with an error when `TEXLIVEFILE` is in a subdirectory, because it will try to put the `.sha` file into a directory that doesn't exist. This change creates that directory.