### PR TITLE
Pin "mirror" to main site CTAN.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN apk --no-cache add \
     xz=${XZ_VERSION} \
     zlib=${ZLIB_VERSION}
 
-ARG ctan_mirror="https://mirrors.ctan.org"
+ARG ctan_mirror="https://ctan.org/tex-archive"
 ENV CTAN_MIRROR=$ctan_mirror
 
 RUN wget "${CTAN_MIRROR}/systems/texlive/tlnet/install-tl-unx.tar.gz" \
@@ -72,13 +72,10 @@ RUN tlversion=$(cat install-tl/release-texlive.txt | head -n 1 | awk '{ print $5
  && ln -s /usr/local/texlive/${tlversion}/bin/x86_64-linuxmusl /usr/local/texlive/${tlversion}/bin/x86_64-linux \
  && ln -s /usr/local/texlive/${tlversion}/bin/x86_64-linuxmusl/mktexlsr /usr/local/bin/mktexlsr
 
-ARG ctan_mirror="https://mirrors.ctan.org"
-ENV CTAN_MIRROR=$ctan_mirror
-
 RUN (  cd install-tl \
     && tlversion=$(cat release-texlive.txt | head -n 1 | awk '{ print $5 }') \
     && sed -i "s/\${tlversion}/${tlversion}/g" ${profile}.profile \
-    && ./install-tl -repository="${CTAN_MIRROR}/systems/texlive/tlnet" -profile ${profile}.profile \
+    && ./install-tl --repository="${CTAN_MIRROR}/systems/texlive/tlnet" -profile ${profile}.profile \
  ) \
  && rm -rf install-tl \
  && tlmgr version | tail -n 1 > version \


### PR DESCRIPTION
Since some days, I have following issues

```
0.311 Automated TeX Live installation using profile: minimal.profile
0.333 Loading https://mirrors.ctan.org/systems/texlive/tlnet/tlpkg/texlive.tlpdb
1.443
1.443 ./install-tl: signature verification error of /tmp/H8kyws46jf/a6uqzkpblW from https://mirrors.ctan.org/systems/texlive/tlnet/tlpkg/texlive.tlpdb: cryptographic signature verification of
1.443   /tmp/H8kyws46jf/mqdoa1xmOW
1.443 against
1.443   https://mirrors.ctan.org/systems/texlive/tlnet/tlpkg/texlive.tlpdb.sha512.asc
1.443 failed. Output was:
1.443 gpg: Signature made Fri Jan 10 00:50:41 2025 UTC
1.443 gpg:                using RSA key D8F2F86057A857E42A88106A4CE1877E19438C70
1.443 gpg: BAD signature from "TeX Live Distribution <tex-live@tug.org>" [ultimate]
1.443
1.443 Please try from a different mirror and/or wait a few minutes
1.443 and try again; usually this is because of transient updates.
1.443 If problems persist, feel free to report to texlive@tug.org.
```

This can be solved to directly use `https://ctan.org/tex-archive` as "mirror". Since this image is not used by millions of people, I think, it is OK to set the main site as source.

Alternatives:

1. Fix mirrors (will be done by the community eventually); however, if one wants to typeset a LaTeX document, one wants to have it working immediatly not after some days.
2. Use `https://mirror.typesetting.eu` as mirror. - This URL only returns mirrors having the most recent sync data. See https://github.com/teatimeguest/setup-texlive-action/issues/250#issuecomment-2042542047 for a discussion (also including a comment by a CTAN maintainer)

---

This PR also fixes duplicate code for `ARG ctan_mirror`.